### PR TITLE
Add VR back in, pegged at r95

### DIFF
--- a/src/controls/VRControls.js
+++ b/src/controls/VRControls.js
@@ -1,0 +1,119 @@
+/**
+ * @author dmarcos / https://github.com/dmarcos
+ * @author mrdoob / http://mrdoob.com
+ *
+ * VRControls from
+ * https://cdn.jsdelivr.net/npm/three@0.93.0/examples/js/controls/VRControls.js.
+ * Added here so that the existing VR examples still work... this will stay
+ * until we get everything upgraded to the modern three.js approach to VR. See
+ * https://threejs.org/docs/index.html#manual/en/introduction/How-to-create-VR-content
+ * for more info.
+ */
+
+import * as THREE from "three";
+
+THREE.VRControls = function (object, onError) {
+  var scope = this;
+
+  var vrDisplay, vrDisplays;
+
+  var standingMatrix = new THREE.Matrix4();
+
+  var frameData = null;
+
+  if ("VRFrameData" in window) {
+    frameData = new VRFrameData();
+  }
+
+  function gotVRDisplays(displays) {
+    vrDisplays = displays;
+
+    if (displays.length > 0) {
+      vrDisplay = displays[0];
+    } else {
+      if (onError) onError("VR input not available.");
+    }
+  }
+
+  if (navigator.getVRDisplays) {
+    navigator
+      .getVRDisplays()
+      .then(gotVRDisplays)
+      .catch(function () {
+        console.warn("THREE.VRControls: Unable to get VR Displays");
+      });
+  }
+
+  // the Rift SDK returns the position in meters
+  // this scale factor allows the user to define how meters
+  // are converted to scene units.
+
+  this.scale = 1;
+
+  // If true will use "standing space" coordinate system where y=0 is the
+  // floor and x=0, z=0 is the center of the room.
+  this.standing = false;
+
+  // Distance from the users eyes to the floor in meters. Used when
+  // standing=true but the VRDisplay doesn't provide stageParameters.
+  this.userHeight = 1.6;
+
+  this.getVRDisplay = function () {
+    return vrDisplay;
+  };
+
+  this.setVRDisplay = function (value) {
+    vrDisplay = value;
+  };
+
+  this.getVRDisplays = function () {
+    console.warn("THREE.VRControls: getVRDisplays() is being deprecated.");
+    return vrDisplays;
+  };
+
+  this.getStandingMatrix = function () {
+    return standingMatrix;
+  };
+
+  this.update = function () {
+    if (vrDisplay) {
+      var pose;
+
+      if (vrDisplay.getFrameData) {
+        vrDisplay.getFrameData(frameData);
+        pose = frameData.pose;
+      } else if (vrDisplay.getPose) {
+        pose = vrDisplay.getPose();
+      }
+
+      if (pose.orientation !== null) {
+        object.quaternion.fromArray(pose.orientation);
+      }
+
+      if (pose.position !== null) {
+        object.position.fromArray(pose.position);
+      } else {
+        object.position.set(0, 0, 0);
+      }
+
+      if (this.standing) {
+        if (vrDisplay.stageParameters) {
+          object.updateMatrix();
+
+          standingMatrix.fromArray(
+            vrDisplay.stageParameters.sittingToStandingTransform
+          );
+          object.applyMatrix(standingMatrix);
+        } else {
+          object.position.setY(object.position.y + this.userHeight);
+        }
+      }
+
+      object.position.multiplyScalar(scope.scale);
+    }
+  };
+
+  this.dispose = function () {
+    vrDisplay = null;
+  };
+};

--- a/src/controls/index.js
+++ b/src/controls/index.js
@@ -1,0 +1,1 @@
+import "./VRControls";


### PR DESCRIPTION
This was all removed from three.js as of version 95, so we'll keep it here so the mathbox VR examples still work.

When the time comes to upgrade, this is the relevant guide: https://threejs.org/docs/index.html#manual/en/introduction/How-to-create-VR-content