### PR TITLE
upgrade to r127

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threestrap",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Minimal Three.js Bootstrapper",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
     "stats.js": "^0.17.0"
   },
   "peerDependencies": {
-    "three": ">=0.66.0 <=0.117.0"
+    "three": ">=0.118.0 <=0.128.0"
   },
   "scripts": {
     "build": "gulp",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "stats.js": "^0.17.0"
   },
   "peerDependencies": {
-    "three": ">=0.118.0 <=0.128.0"
+    "three": ">=0.118.0 <=0.127.0"
   },
   "scripts": {
     "build": "gulp",

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -3,7 +3,7 @@ import "../bootstrap";
 
 THREE.Bootstrap.registerPlugin("renderer", {
   defaults: {
-    klass: THREE.WebGLRenderer,
+    klass: THREE.WebGL1Renderer,
     parameters: {
       depth: true,
       stencil: true,


### PR DESCRIPTION
Getting past r117 in Mathbox required a change from `WebGLRenderer` to `WebGL1Renderer`. That's worth a new version here.