### PR TITLE
use bare "three" imports

### DIFF
--- a/src/binder.js
+++ b/src/binder.js
@@ -1,4 +1,4 @@
-import { EventDispatcher } from "three/src/core/EventDispatcher.js";
+import { EventDispatcher } from "three";
 
 export class Binder {
   static bind(context, globals) {

--- a/src/controls/VRControls.js
+++ b/src/controls/VRControls.js
@@ -10,7 +10,7 @@
  * for more info.
  */
 
-import { Matrix4 } from "three/src/math/Matrix4.js";
+import { Matrix4 } from "three";
 
 export class VRControls {
   constructor(object, onError) {

--- a/src/core/camera.js
+++ b/src/core/camera.js
@@ -1,6 +1,4 @@
-import { Camera } from "three/src/cameras/Camera.js";
-import { OrthographicCamera } from "three/src/cameras/OrthographicCamera.js";
-import { PerspectiveCamera } from "three/src/cameras/PerspectiveCamera.js";
+import { Camera, OrthographicCamera, PerspectiveCamera } from "three";
 import { Bootstrap } from "../bootstrap";
 
 Bootstrap.registerPlugin("camera", {

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -1,4 +1,4 @@
-import { WebGL1Renderer } from "three/src/renderers/WebGL1Renderer.js";
+import { WebGL1Renderer } from "three";
 import { Bootstrap } from "../bootstrap";
 
 Bootstrap.registerPlugin("renderer", {

--- a/src/core/scene.js
+++ b/src/core/scene.js
@@ -1,4 +1,4 @@
-import { Scene } from "three/src/scenes/Scene.js";
+import { Scene } from "three";
 import { Bootstrap } from "../bootstrap";
 
 Bootstrap.registerPlugin("scene", {

--- a/src/extra/controls.js
+++ b/src/extra/controls.js
@@ -1,4 +1,4 @@
-import { PerspectiveCamera } from "three/src/cameras/PerspectiveCamera.js";
+import { PerspectiveCamera } from "three";
 import { Bootstrap } from "../bootstrap";
 
 Bootstrap.registerPlugin("controls", {

--- a/src/renderers/VRRenderer.js
+++ b/src/renderers/VRRenderer.js
@@ -4,8 +4,7 @@
  * @author wwwtyro https://github.com/wwwtyro
  * @author unconed https://github.com/unconed
  */
-import { PerspectiveCamera } from "three/src/cameras/PerspectiveCamera.js";
-import { Vector3 } from "three/src/math/Vector3.js";
+import { PerspectiveCamera, Vector3 } from "three";
 
 export class VRRenderer {
   constructor(renderer, hmd) {

--- a/test/core/camera.spec.js
+++ b/test/core/camera.spec.js
@@ -1,6 +1,5 @@
 import * as Threestrap from "../../src";
-import { OrthographicCamera } from "three/src/cameras/OrthographicCamera.js";
-import { PerspectiveCamera } from "three/src/cameras/PerspectiveCamera.js";
+import { OrthographicCamera, PerspectiveCamera } from "three";
 
 describe("camera", function () {
   it("installs a perspective camera", function () {

--- a/test/core/render.spec.js
+++ b/test/core/render.spec.js
@@ -1,7 +1,5 @@
 import * as Threestrap from "../../src";
-import { Scene } from "three";
-import { PerspectiveCamera } from "three/src/cameras/PerspectiveCamera.js";
-
+import { Scene, PerspectiveCamera } from "three";
 
 describe("render", function () {
   it("renders the scene on update", function () {

--- a/test/core/renderer.spec.js
+++ b/test/core/renderer.spec.js
@@ -1,5 +1,5 @@
 import * as Threestrap from "../../src";
-import { WebGL1Renderer } from "three/src/renderers/WebGL1Renderer.js";
+import { WebGL1Renderer } from "three";
 
 describe("renderer", function () {
   it("installs the canvas into the body", function () {

--- a/test/core/scene.spec.js
+++ b/test/core/scene.spec.js
@@ -1,5 +1,5 @@
 import * as Threestrap from "../../src";
-import { Scene } from "three/src/scenes/Scene.js";
+import { Scene } from "three";
 
 describe("scene", function () {
   it("makes a scene", function () {

--- a/test/extra/controls.spec.js
+++ b/test/extra/controls.spec.js
@@ -1,5 +1,5 @@
 import * as Threestrap from "../../src"
-import { PerspectiveCamera } from "three/src/cameras/PerspectiveCamera.js";
+import { PerspectiveCamera } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -38,10 +38,6 @@ const library: Configuration = {
   },
   externals: {
     three: "THREE",
-    "three/src/core/EventDispatcher.js": "THREE",
-    "three/src/renderers/WebGL1Renderer.js": "THREE",
-    "three/src/scenes/Scene.js": "THREE",
-    "three/src/cameras/PerspectiveCamera.js": "THREE",
   },
   optimization: {
     minimize: true,


### PR DESCRIPTION
I was working on https://github.com/unconed/mathbox/issues/49 and realized we should do the same for this library 
### What does this do
Previously we were importing from specific three/src files. Now we just import from `"three"`.

 Why change? Because:
    1. we can still tree shake
    2. we were actually (indirectly) using bare imports before, too. E.g., ThreeStrap imports from "three/examples/jsm/controls/OrbitControls", and OrbitControls imports bare "three"
    3. "three" seems like the more official import pattern; it's what is documented at https://threejs.org/docs/#manual/en/introduction/Installation

### Related
See also https://github.com/unconed/mathbox/issues/49

### Some numbers
I was not expecting this to affect bundle sizes very significantly, but it actually did reduce the bundle size pretty significantly, at least for webpack, I think because of (2) above: previously we were including `three/src` directly, and `three/build` indirectly (via imports like `three/examples/jsm/controls/OrbitControls`). 

I published a version of threestrap on npm that includes this change, `v0.5.1-rc1` and testing with https://github.com/ChristopherChudzicki/bundling-tests:
```
            0.5.0   0.5.1-rc
webpack     859K    439K
vite        441K    419K
```
So, that's cool.